### PR TITLE
Add serverless sharing endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 Tiny Tales is a small, playful space for young storytellers. Kids speak their idea for each
 page, and our friendly AI turns those words into pictures.
 
-Every book lives only in this browser. Nothing is uploaded or shared unless you choose
-to, so children can create freely and safely.
+Books live in the browser by default. When you hit share, the story is uploaded
+to a temporary serverless store and you get a link to send around. Offline
+creation still works just the same.
 
 https://www.trytinytales.com/

--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -3,11 +3,10 @@ import { getStoredBook } from "@/lib/server-db"
 
 export const runtime = "nodejs"
 
-export async function GET(
-  _req: Request,
-  { params }: { params: { id: string } },
-) {
-  const book = getStoredBook(params.id)
-  if (!book) return NextResponse.json({ error: "Not found" }, { status: 404 })
-  return NextResponse.json(book)
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const book = getStoredBook(id)
+
+  if (book == null) return NextResponse.json({ error: "Not found" }, { status: 404 })
+  else return NextResponse.json(book)
 }

--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server"
+import { getStoredBook } from "@/lib/server-db"
+
+export const runtime = "nodejs"
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } },
+) {
+  const book = getStoredBook(params.id)
+  if (!book) return NextResponse.json({ error: "Not found" }, { status: 404 })
+  return NextResponse.json(book)
+}

--- a/src/app/api/books/route.ts
+++ b/src/app/api/books/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server"
+import { Book } from "@/lib/types"
+import { storeBook } from "@/lib/server-db"
+
+export const runtime = "nodejs"
+
+export async function POST(req: Request) {
+  const book = (await req.json()) as Book
+  const id = storeBook(book)
+  return NextResponse.json({ id })
+}

--- a/src/app/share/[id]/page.tsx
+++ b/src/app/share/[id]/page.tsx
@@ -1,0 +1,20 @@
+import { notFound } from "next/navigation"
+import { BookViewer } from "@/components/book-viewer"
+import { Header } from "@/components/header"
+import { getStoredBook } from "@/lib/server-db"
+
+interface Props {
+  params: { id: string }
+}
+
+export default async function SharedBookPage({ params }: Props) {
+  const book = getStoredBook(params.id)
+  if (!book) return notFound()
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto">
+      <Header />
+      <BookViewer book={book} />
+    </div>
+  )
+}

--- a/src/app/share/[id]/page.tsx
+++ b/src/app/share/[id]/page.tsx
@@ -1,15 +1,18 @@
 import { notFound } from "next/navigation"
+import { use } from "react"
 import { BookViewer } from "@/components/book-viewer"
 import { Header } from "@/components/header"
 import { getStoredBook } from "@/lib/server-db"
 
 interface Props {
-  params: { id: string }
+  params: Promise<{ id: string }>
 }
 
-export default async function SharedBookPage({ params }: Props) {
-  const book = getStoredBook(params.id)
-  if (!book) return notFound()
+export default function SharedBookPage({ params }: Props) {
+  const { id } = use(params)
+  const book = getStoredBook(id)
+
+  if (book == null) return notFound()
 
   return (
     <div className="p-6 max-w-2xl mx-auto">

--- a/src/components/book-viewer.tsx
+++ b/src/components/book-viewer.tsx
@@ -8,7 +8,7 @@ import { DeleteBookButton } from "@/components/book-delete-button"
 import { BookNavButtons } from "@/components/book-nav-buttons"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { shareBookAsImage } from "@/lib/share-book-image"
+import { shareBookOnline } from "@/lib/share-book-online"
 import { Book } from "@/lib/types"
 
 interface Props {
@@ -41,6 +41,17 @@ export function BookViewer({ book }: Props) {
         img.src = pages[i].image
       })
   }, [pageIndex, pages])
+
+  const handleShare = async () => {
+    const url = await shareBookOnline(book)
+    if (!url) return
+    if (navigator.share) {
+      await navigator.share({ url, title: book.title })
+    } else {
+      await navigator.clipboard.writeText(url)
+      alert("Link copied to clipboard")
+    }
+  }
 
   if (pages.length === 0) {
     return (
@@ -98,7 +109,7 @@ export function BookViewer({ book }: Props) {
       </Card>
 
       <div className="flex gap-3 items-center">
-        <Button variant="outline" aria-label="Share book" onClick={() => shareBookAsImage(book)}>
+        <Button variant="outline" aria-label="Share book" onClick={handleShare}>
           <Share className="mr-1" />
           <span>Share</span>
         </Button>

--- a/src/lib/server-db.ts
+++ b/src/lib/server-db.ts
@@ -1,0 +1,14 @@
+import { Book } from "@/lib/types"
+import { v4 as uuid } from "uuid"
+
+const books = new Map<string, Book>()
+
+export function storeBook(book: Book): string {
+  const id = uuid()
+  books.set(id, book)
+  return id
+}
+
+export function getStoredBook(id: string): Book | undefined {
+  return books.get(id)
+}

--- a/src/lib/share-book-online.ts
+++ b/src/lib/share-book-online.ts
@@ -1,0 +1,20 @@
+import { upsertBook } from "@/lib/storage"
+import { Book } from "@/lib/types"
+
+export async function shareBookOnline(book: Book): Promise<string | undefined> {
+  try {
+    const res = await fetch("/api/books", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(book),
+    })
+    const data = await res.json()
+    if (data.id) {
+      const updated = { ...book, remoteId: data.id }
+      upsertBook(updated)
+      return `${location.origin}/share/${data.id}`
+    }
+  } catch (err) {
+    console.error("shareBookOnline", err)
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,4 +9,5 @@ export interface Book {
   title: string
   pages: Page[]
   createdAt: number
+  remoteId?: string
 }


### PR DESCRIPTION
## Summary
- allow optional online sharing
- API for storing and retrieving books
- share page that renders books from the server
- client button uploads the book and shares the link

## Testing
- `npm run build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f97904148324b27d8b7b3eb5965e