### PR TITLE
Fix page index update when deleting pages

### DIFF
--- a/src/components/book-editor-state.ts
+++ b/src/components/book-editor-state.ts
@@ -44,10 +44,12 @@ export function reducer(state: State, action: Action): State {
         }
       }
 
+      const pages = state.pages.filter((_, idx) => idx !== action.pageIndex)
+
       return {
         ...state,
-        pages: state.pages.filter((_, idx) => idx !== action.pageIndex),
-        pageIndex: Math.max(0, action.pageIndex - 1),
+        pages,
+        pageIndex: Math.min(action.pageIndex, pages.length - 1),
       }
     }
 


### PR DESCRIPTION
## Summary
- ensure BookEditor reducer keeps current page index if deleting a middle page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853fc4212388324a9158e0a3b86bcf8