### PR TITLE
Handle generate/transcribe errors

### DIFF
--- a/src/components/book-editor-state.ts
+++ b/src/components/book-editor-state.ts
@@ -19,7 +19,12 @@ type Action =
   | { type: "SET_PAGE_INDEX"; pageIndex: number }
   | { type: "ADD_PAGE" }
   | { type: "DELETE_PAGE"; pageIndex: number }
-  | { type: "UPDATE_PAGE"; pageIndex: number; payload: Partial<PageDraft> }
+  | {
+      type: "UPDATE_PAGE"
+      pageIndex: number
+      payload: Partial<PageDraft>
+      error?: string
+    }
 
 export function reducer(state: State, action: Action): State {
   switch (action.type) {
@@ -64,6 +69,7 @@ export function reducer(state: State, action: Action): State {
         pages: state.pages.map((page, idx) =>
           idx === action.pageIndex ? { ...page, ...action.payload } : page
         ),
+        error: action.error,
       }
 
     default:
@@ -83,6 +89,7 @@ export function getInitialState(book: Book, pageIndex: number): State {
           })),
     pageIndex: Math.max(0, Math.min(pageIndex, book.pages.length - 1)),
     title: book.title,
+    error: undefined,
   }
 }
 

--- a/src/components/book-editor-ui.tsx
+++ b/src/components/book-editor-ui.tsx
@@ -39,9 +39,10 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
   const captionText = getValue(page.caption, "")
   const imageUrl = getValue(page.image)
 
-  const makePageUpdater = (idx: number) => (payload: Partial<PageDraft>) => {
-    dispatch({ type: "UPDATE_PAGE", pageIndex: idx, payload })
-  }
+  const makePageUpdater =
+    (idx: number) => (payload: Partial<PageDraft>, error?: string) => {
+      dispatch({ type: "UPDATE_PAGE", pageIndex: idx, payload, error })
+    }
 
   const handleDeleteCurrentPage = () => {
     dispatch({ type: "DELETE_PAGE", pageIndex: state.pageIndex })
@@ -75,7 +76,7 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
     if (captionText.trim().length === 0 || isLoading(page.image)) return
 
     const updatePage = makePageUpdater(state.pageIndex)
-    updatePage({ image: asyncLoading() })
+    updatePage({ image: asyncLoading() }, undefined)
 
     try {
       const res = await fetch("/api/generate-image", {
@@ -88,7 +89,10 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
       updatePage({ image: asyncLoaded(imageUrl) })
     } catch (error) {
       console.error("Image generation fail", error)
-      updatePage({ image: asyncFailedToLoad("Image generation failed") })
+      updatePage(
+        { image: asyncFailedToLoad("Image generation failed") },
+        "Image generation failed"
+      )
     }
   }
 
@@ -98,7 +102,7 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
       formData.append("file", blob, "recording.webm")
 
       const updatePage = makePageUpdater(state.pageIndex)
-      updatePage({ caption: asyncLoading() })
+      updatePage({ caption: asyncLoading() }, undefined)
 
       try {
         const res = await fetch("/api/transcribe", { method: "POST", body: formData })
@@ -107,7 +111,10 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
         updatePage({ caption: asyncLoaded(transcript) })
       } catch (error) {
         console.error("Transcription fail", error)
-        updatePage({ caption: asyncFailedToLoad("Transcription failed") })
+        updatePage(
+          { caption: asyncFailedToLoad("Transcription failed") },
+          "Transcription failed"
+        )
       }
     },
   })

--- a/src/components/book-editor-ui.tsx
+++ b/src/components/book-editor-ui.tsx
@@ -76,7 +76,7 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
     if (captionText.trim().length === 0 || isLoading(page.image)) return
 
     const updatePage = makePageUpdater(state.pageIndex)
-    updatePage({ image: asyncLoading() }, undefined)
+    updatePage({ image: asyncLoading() })
 
     try {
       const res = await fetch("/api/generate-image", {
@@ -102,7 +102,7 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
       formData.append("file", blob, "recording.webm")
 
       const updatePage = makePageUpdater(state.pageIndex)
-      updatePage({ caption: asyncLoading() }, undefined)
+      updatePage({ caption: asyncLoading() })
 
       try {
         const res = await fetch("/api/transcribe", { method: "POST", body: formData })


### PR DESCRIPTION
## Summary
- track request errors in `book-editor-state`
- dispatch error updates from `BookEditor` via `updatePage`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist Mono`)*


------
https://chatgpt.com/codex/tasks/task_e_6853fd2f3490832499fef5257503a6f6