### PR TITLE
Add shared book callout banner

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,2 @@
 - remove / change buttons below book viewer for shared book
-- add special callout / message atop book on share page?
+- add special callout / message atop book on share page? ✅

--- a/src/app/share/[id]/page.tsx
+++ b/src/app/share/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation"
 import { use } from "react"
 import { BookViewer } from "@/components/book-viewer"
 import { Header } from "@/components/header"
+import { SharedBookBanner } from "@/components/shared-book-banner"
 import { getStoredBook } from "@/lib/server-db"
 
 interface Props {
@@ -17,6 +18,7 @@ export default function SharedBookPage({ params }: Props) {
   return (
     <div className="p-6 max-w-2xl mx-auto">
       <Header />
+      <SharedBookBanner />
       <BookViewer book={book} />
     </div>
   )

--- a/src/components/shared-book-banner.tsx
+++ b/src/components/shared-book-banner.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link"
+
+export function SharedBookBanner() {
+  return (
+    <div className="mb-6 rounded-lg bg-yellow-100 p-4 text-yellow-900">
+      <p className="text-sm">
+        📖 You’re viewing a book that was shared with you.{' '}
+        <Link href="/" className="underline">Create your own</Link>.
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `SharedBookBanner` component
- display banner on shared book page
- mark TODO complete

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68588a48c4d48324af4f0368a3fcbe41