### PR TITLE
Remove editing controls from shared book view

### DIFF
--- a/src/app/share/[id]/page.tsx
+++ b/src/app/share/[id]/page.tsx
@@ -17,7 +17,7 @@ export default function SharedBookPage({ params }: Props) {
   return (
     <div className="p-6 max-w-2xl mx-auto">
       <Header />
-      <BookViewer book={book} />
+      <BookViewer book={book} showActions={false} />
     </div>
   )
 }

--- a/src/components/book-viewer.tsx
+++ b/src/components/book-viewer.tsx
@@ -13,9 +13,10 @@ import { Book } from "@/lib/types"
 
 interface Props {
   book: Book
+  showActions?: boolean
 }
 
-export function BookViewer({ book }: Props) {
+export function BookViewer({ book, showActions = true }: Props) {
   const [pageIndex, setPageIndex] = useState(0)
 
   const { pages } = book
@@ -108,21 +109,23 @@ export function BookViewer({ book }: Props) {
         </CardContent>
       </Card>
 
-      <div className="flex gap-3 items-center">
-        <Button variant="outline" aria-label="Share book" onClick={handleShare}>
-          <Share className="mr-1" />
-          <span>Share</span>
-        </Button>
-        <Link
-          href={`/books/${book.id}/edit?page=${pageIndex}`}
-          className={buttonVariants({ variant: "outline" })}
-        >
-          <Edit className="mr-1" />
-          <span className="sm:hidden">Change</span>
-          <span className="hidden sm:inline">Make changes</span>
-        </Link>
-        <DeleteBookButton id={book.id} />
-      </div>
+      {showActions && (
+        <div className="flex gap-3 items-center">
+          <Button variant="outline" aria-label="Share book" onClick={handleShare}>
+            <Share className="mr-1" />
+            <span>Share</span>
+          </Button>
+          <Link
+            href={`/books/${book.id}/edit?page=${pageIndex}`}
+            className={buttonVariants({ variant: "outline" })}
+          >
+            <Edit className="mr-1" />
+            <span className="sm:hidden">Change</span>
+            <span className="hidden sm:inline">Make changes</span>
+          </Link>
+          <DeleteBookButton id={book.id} />
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- optionally hide BookViewer actions
- don't show edit/share/delete actions on shared book page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68588a6f13c48324975639c08c72fd74