### PR TITLE
Improve viewer image loading

### DIFF
--- a/src/components/book-viewer.tsx
+++ b/src/components/book-viewer.tsx
@@ -9,10 +9,10 @@ import { DeleteBookButton } from "@/components/book-delete-button"
 import { BookNavButtons } from "@/components/book-nav-buttons"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { shareBookOnline } from "@/lib/share-book-online"
-import { cn } from "@/lib/utils"
-import { Book } from "@/lib/types"
 import { usePageImageLoader } from "@/hooks/usePageImageLoader"
+import { shareBookOnline } from "@/lib/share-book-online"
+import { Book } from "@/lib/types"
+import { cn } from "@/lib/utils"
 
 interface Props {
   book: Book
@@ -26,7 +26,7 @@ export function BookViewer({ book, showActions = true }: Props) {
   const currentPage = pages[pageIndex]
   const { caption, image } = currentPage ?? {}
 
-  const { imageLoaded, markImageLoaded } = usePageImageLoader(pages, pageIndex)
+  const { isImageLoaded, markImageLoaded } = usePageImageLoader(pages, pageIndex)
 
   const swipeHandlers = useSwipeable({
     trackTouch: true,
@@ -34,7 +34,6 @@ export function BookViewer({ book, showActions = true }: Props) {
     onSwipedLeft: () => setPageIndex((prev) => Math.min(prev + 1, pages.length - 1)),
     onSwipedRight: () => setPageIndex((prev) => Math.max(prev - 1, 0)),
   })
-
 
   const handleShare = async () => {
     const url = await shareBookOnline(book)
@@ -65,33 +64,32 @@ export function BookViewer({ book, showActions = true }: Props) {
     <div className="space-y-3">
       <div className="font-bold text-lg">{book.title || "(Untitled)"}</div>
 
-      <Card className=" mb-4 p-0 relative">
+      <Card className="mb-4 p-0 relative">
         <CardContent className="p-0">
           <div className="grid md:grid-cols-2 md:aspect-2/1">
             <div
-              className="relative aspect-square bg-gray-100 card-inner-radius"
+              className="max-sm:relative aspect-square bg-gray-100 card-inner-radius"
               {...swipeHandlers}
             >
               {image && (
-                <>
+                <div className="relative w-full h-full">
                   <ImageComponent
                     key={image}
-                    src={image}
                     alt={caption}
-                    fill
-                    sizes="(min-width: 768px) 50vw, 100vw"
                     className={cn(
                       "object-cover card-inner-radius transition-opacity",
-                      imageLoaded ? "opacity-100" : "opacity-0"
+                      isImageLoaded ? "opacity-100" : "opacity-0"
                     )}
-                    onLoadingComplete={() => markImageLoaded(image ?? "")}
+                    fill={true}
+                    onLoad={() => markImageLoaded(image)}
+                    src={image}
                   />
-                  {!imageLoaded && (
-                    <div className="absolute inset-0 flex items-center justify-center card-inner-radius bg-gray-100">
+                  {!isImageLoaded && (
+                    <div className="absolute inset-0 flex items-center justify-center card-inner-radius">
                       <Loader2 className="h-6 w-6 animate-spin text-gray-500" />
                     </div>
                   )}
-                </>
+                </div>
               )}
               <BookNavButtons
                 prevDisabled={pages.length <= 1}

--- a/src/components/book-viewer.tsx
+++ b/src/components/book-viewer.tsx
@@ -1,15 +1,18 @@
 "use client"
 
-import { Edit, Share } from "lucide-react"
+import { Edit, Share, Loader2 } from "lucide-react"
+import ImageComponent from "next/image"
 import Link from "next/link"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { useSwipeable } from "react-swipeable"
 import { DeleteBookButton } from "@/components/book-delete-button"
 import { BookNavButtons } from "@/components/book-nav-buttons"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { shareBookOnline } from "@/lib/share-book-online"
+import { cn } from "@/lib/utils"
 import { Book } from "@/lib/types"
+import { usePageImageLoader } from "@/hooks/usePageImageLoader"
 
 interface Props {
   book: Book
@@ -23,6 +26,8 @@ export function BookViewer({ book, showActions = true }: Props) {
   const currentPage = pages[pageIndex]
   const { caption, image } = currentPage ?? {}
 
+  const { imageLoaded, markImageLoaded } = usePageImageLoader(pages, pageIndex)
+
   const swipeHandlers = useSwipeable({
     trackTouch: true,
     trackMouse: false,
@@ -30,17 +35,6 @@ export function BookViewer({ book, showActions = true }: Props) {
     onSwipedRight: () => setPageIndex((prev) => Math.max(prev - 1, 0)),
   })
 
-  useEffect(() => {
-    // preload the current and next page images (for smoother navigation)
-    const currentAndNextPages = [pageIndex, pageIndex + 1]
-    currentAndNextPages
-      .filter((i) => i < pages.length && pages[i].image.length > 0) // stay in-bounds
-      .forEach((i) => {
-        const img = new Image()
-        img.crossOrigin = "anonymous"
-        img.src = pages[i].image
-      })
-  }, [pageIndex, pages])
 
   const handleShare = async () => {
     const url = await shareBookOnline(book)
@@ -75,15 +69,29 @@ export function BookViewer({ book, showActions = true }: Props) {
         <CardContent className="p-0">
           <div className="grid md:grid-cols-2 md:aspect-2/1">
             <div
-              className="max-sm:relative aspect-square bg-gray-100 card-inner-radius"
+              className="relative aspect-square bg-gray-100 card-inner-radius"
               {...swipeHandlers}
             >
               {image && (
-                <img
-                  src={image}
-                  alt={caption}
-                  className="w-full h-full object-cover card-inner-radius"
-                />
+                <>
+                  <ImageComponent
+                    key={image}
+                    src={image}
+                    alt={caption}
+                    fill
+                    sizes="(min-width: 768px) 50vw, 100vw"
+                    className={cn(
+                      "object-cover card-inner-radius transition-opacity",
+                      imageLoaded ? "opacity-100" : "opacity-0"
+                    )}
+                    onLoadingComplete={() => markImageLoaded(image ?? "")}
+                  />
+                  {!imageLoaded && (
+                    <div className="absolute inset-0 flex items-center justify-center card-inner-radius bg-gray-100">
+                      <Loader2 className="h-6 w-6 animate-spin text-gray-500" />
+                    </div>
+                  )}
+                </>
               )}
               <BookNavButtons
                 prevDisabled={pages.length <= 1}

--- a/src/hooks/usePageImageLoader.ts
+++ b/src/hooks/usePageImageLoader.ts
@@ -1,26 +1,24 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { Page } from "@/lib/types"
 
 export function usePageImageLoader(pages: Page[], pageIndex: number) {
-  const [imageLoaded, setImageLoaded] = useState(false)
+  const [isImageLoaded, setIsImageLoaded] = useState(false)
   const loadedImages = useRef(new Set<string>())
 
   const image = pages[pageIndex]?.image
 
   useEffect(() => {
-    if (image) {
-      setImageLoaded(loadedImages.current.has(image))
-    } else {
-      setImageLoaded(false)
-    }
+    if (image) setIsImageLoaded(loadedImages.current.has(image))
+    else setIsImageLoaded(false)
   }, [image])
 
   useEffect(() => {
-    const indices = [pageIndex, pageIndex + 1]
-    indices
-      .filter((i) => i < pages.length && pages[i].image.length > 0)
+    // preload the current and next page images (for smoother navigation)
+    const currentAndNextPages = [pageIndex, pageIndex + 1]
+    currentAndNextPages
+      .filter((i) => i < pages.length && pages[i].image.length > 0) // stay in-bounds
       .forEach((i) => {
         const src = pages[i].image
         if (loadedImages.current.has(src)) return
@@ -31,10 +29,13 @@ export function usePageImageLoader(pages: Page[], pageIndex: number) {
       })
   }, [pageIndex, pages])
 
-  const markImageLoaded = (src: string) => {
+  const markImageLoaded = useCallback((src: string) => {
     loadedImages.current.add(src)
-    setImageLoaded(true)
-  }
+    setIsImageLoaded(true)
+  }, [])
 
-  return { imageLoaded, markImageLoaded }
+  return {
+    isImageLoaded,
+    markImageLoaded,
+  }
 }

--- a/src/hooks/usePageImageLoader.ts
+++ b/src/hooks/usePageImageLoader.ts
@@ -1,0 +1,40 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { Page } from "@/lib/types"
+
+export function usePageImageLoader(pages: Page[], pageIndex: number) {
+  const [imageLoaded, setImageLoaded] = useState(false)
+  const loadedImages = useRef(new Set<string>())
+
+  const image = pages[pageIndex]?.image
+
+  useEffect(() => {
+    if (image) {
+      setImageLoaded(loadedImages.current.has(image))
+    } else {
+      setImageLoaded(false)
+    }
+  }, [image])
+
+  useEffect(() => {
+    const indices = [pageIndex, pageIndex + 1]
+    indices
+      .filter((i) => i < pages.length && pages[i].image.length > 0)
+      .forEach((i) => {
+        const src = pages[i].image
+        if (loadedImages.current.has(src)) return
+        const img = new Image()
+        img.crossOrigin = "anonymous"
+        img.onload = () => loadedImages.current.add(src)
+        img.src = src
+      })
+  }, [pageIndex, pages])
+
+  const markImageLoaded = (src: string) => {
+    loadedImages.current.add(src)
+    setImageLoaded(true)
+  }
+
+  return { imageLoaded, markImageLoaded }
+}


### PR DESCRIPTION
## Summary
- refactor image loading and preloading logic into `usePageImageLoader`
- clean up `BookViewer` to use the new hook

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68594911ba188324a45d7e8c62caece5