### PR TITLE
Fix remote book sync after edits

### DIFF
--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -7,14 +7,13 @@ export const runtime = "nodejs"
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const book = await getStoredBook(id)
-
   if (book == null) return NextResponse.json({ error: "Not found" }, { status: 404 })
   else return NextResponse.json(book)
 }
 
 export async function PUT(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
-  const book = (await req.json()) as Book
-  await updateStoredBook(id, book)
+  const book = await req.json()
+  await updateStoredBook(id, book as Book)
   return NextResponse.json({ ok: true })
 }

--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
-import { getStoredBook } from "@/lib/server-db"
+import { getStoredBook, updateStoredBook } from "@/lib/server-db"
+import { Book } from "@/lib/types"
 
 export const runtime = "nodejs"
 
@@ -9,4 +10,11 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
 
   if (book == null) return NextResponse.json({ error: "Not found" }, { status: 404 })
   else return NextResponse.json(book)
+}
+
+export async function PUT(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const book = (await req.json()) as Book
+  await updateStoredBook(id, book)
+  return NextResponse.json({ ok: true })
 }

--- a/src/components/book-editor-ui.tsx
+++ b/src/components/book-editor-ui.tsx
@@ -27,6 +27,7 @@ import {
   isLoading,
 } from "@/lib/async-data"
 import { upsertBook } from "@/lib/storage"
+import { updateBookOnline } from "@/lib/share-book-online"
 import { Book } from "@/lib/types"
 
 export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: number }) {
@@ -56,8 +57,8 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
     })
   }
 
-  const handleSaveBook = () => {
-    upsertBook({
+  const handleSaveBook = async () => {
+    const updatedBook = {
       ...book,
       title: state.title,
       pages: state.pages
@@ -67,7 +68,12 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
           image: getValue(page.image, ""),
         }))
         .filter((page) => page.caption || page.image),
-    })
+    }
+
+    upsertBook(updatedBook)
+    if (book.remoteId) {
+      await updateBookOnline(updatedBook)
+    }
 
     router.push(`/books/${book.id}?celebrate=1`)
   }

--- a/src/components/book-editor-ui.tsx
+++ b/src/components/book-editor-ui.tsx
@@ -40,10 +40,9 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
   const captionText = getValue(page.caption, "")
   const imageUrl = getValue(page.image)
 
-  const makePageUpdater =
-    (idx: number) => (payload: Partial<PageDraft>, error?: string) => {
-      dispatch({ type: "UPDATE_PAGE", pageIndex: idx, payload, error })
-    }
+  const makePageUpdater = (idx: number) => (payload: Partial<PageDraft>, error?: string) => {
+    dispatch({ type: "UPDATE_PAGE", pageIndex: idx, payload, error })
+  }
 
   const handleDeleteCurrentPage = () => {
     dispatch({ type: "DELETE_PAGE", pageIndex: state.pageIndex })
@@ -71,7 +70,7 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
     }
 
     upsertBook(updatedBook)
-    if (book.remoteId) {
+    if (book.remoteId != null) {
       await updateBookOnline(updatedBook)
     }
 
@@ -117,10 +116,7 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
       updatePage({ image: asyncLoaded(imageUrl) })
     } catch (error) {
       console.error("Image generation fail", error)
-      updatePage(
-        { image: asyncFailedToLoad("Image generation failed") },
-        "Image generation failed"
-      )
+      updatePage({ image: asyncFailedToLoad("Image generation failed") }, "Image generation failed")
     }
   }
 
@@ -139,10 +135,7 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
         updatePage({ caption: asyncLoaded(transcript) })
       } catch (error) {
         console.error("Transcription fail", error)
-        updatePage(
-          { caption: asyncFailedToLoad("Transcription failed") },
-          "Transcription failed"
-        )
+        updatePage({ caption: asyncFailedToLoad("Transcription failed") }, "Transcription failed")
       }
     },
   })

--- a/src/lib/rgb-data-url.ts
+++ b/src/lib/rgb-data-url.ts
@@ -1,0 +1,14 @@
+// adapted from https://github.com/vercel/next.js/blob/canary/examples/image-component/app/color/page.tsx
+
+const keyStr = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
+
+const triplet = (e1: number, e2: number, e3: number) =>
+  keyStr.charAt(e1 >> 2) +
+  keyStr.charAt(((e1 & 3) << 4) | (e2 >> 4)) +
+  keyStr.charAt(((e2 & 15) << 2) | (e3 >> 6)) +
+  keyStr.charAt(e3 & 63)
+
+export const rgbDataURL = (r: number, g: number, b: number) =>
+  `data:image/gif;base64,R0lGODlhAQABAPAA${
+    triplet(0, r, g) + triplet(b, 255, 255)
+  }/yH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==`

--- a/src/lib/server-db.ts
+++ b/src/lib/server-db.ts
@@ -13,3 +13,7 @@ export async function storeBook(book: Book): Promise<string> {
 export async function getStoredBook(id: string): Promise<Book | undefined> {
   return (await redis.get<Book>(id)) ?? undefined
 }
+
+export async function updateStoredBook(id: string, book: Book): Promise<void> {
+  await redis.set(id, book)
+}

--- a/src/lib/share-book-online.ts
+++ b/src/lib/share-book-online.ts
@@ -18,3 +18,16 @@ export async function shareBookOnline(book: Book): Promise<string | undefined> {
     console.error("shareBookOnline", err)
   }
 }
+
+export async function updateBookOnline(book: Book): Promise<void> {
+  if (!book.remoteId) return
+  try {
+    await fetch(`/api/books/${book.remoteId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(book),
+    })
+  } catch (err) {
+    console.error("updateBookOnline", err)
+  }
+}

--- a/src/lib/share-book-online.ts
+++ b/src/lib/share-book-online.ts
@@ -20,7 +20,7 @@ export async function shareBookOnline(book: Book): Promise<string | undefined> {
 }
 
 export async function updateBookOnline(book: Book): Promise<void> {
-  if (!book.remoteId) return
+  if (book.remoteId == null) return
   try {
     await fetch(`/api/books/${book.remoteId}`, {
       method: "PUT",


### PR DESCRIPTION
## Summary
- support updating stored books on the server
- expose `PUT /api/books/[id]`
- add client helper to update a shared book
- sync remote copy when saving an edited book

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b36d7715083249cada52601dee993