### PR TITLE
Add new page on next nav

### DIFF
--- a/src/components/book-editor-state.ts
+++ b/src/components/book-editor-state.ts
@@ -105,16 +105,16 @@ export function getInitialState(book: Book, pageIndex: number): State {
   }
 }
 
+export function isPageEmpty(page: PageDraft): boolean {
+  const caption = getValue(page.caption, "").trim()
+  const image = getValue(page.image, "").trim()
+  return caption === "" && image === ""
+}
+
 function createEmptyPage(): PageDraft {
   return {
     id: uuid(),
     caption: asyncNotStarted(),
     image: asyncNotStarted(),
   }
-}
-
-function isPageEmpty(page: PageDraft): boolean {
-  const caption = getValue(page.caption, "").trim()
-  const image = getValue(page.image, "").trim()
-  return caption === "" && image === ""
 }

--- a/src/components/book-editor-ui.tsx
+++ b/src/components/book-editor-ui.tsx
@@ -234,9 +234,20 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
 
         <BookNavButtons
           prevDisabled={state.pageIndex === 0 || isRecording}
-          prevOnClick={() => dispatch({ type: "SET_PAGE_INDEX", pageIndex: state.pageIndex - 1 })}
-          nextDisabled={state.pageIndex === state.pages.length - 1 || isRecording}
-          nextOnClick={() => dispatch({ type: "SET_PAGE_INDEX", pageIndex: state.pageIndex + 1 })}
+          prevOnClick={() =>
+            dispatch({ type: "SET_PAGE_INDEX", pageIndex: state.pageIndex - 1 })
+          }
+          nextDisabled={isRecording}
+          nextOnClick={() => {
+            if (state.pageIndex === state.pages.length - 1) {
+              dispatch({ type: "ADD_PAGE" })
+            } else {
+              dispatch({
+                type: "SET_PAGE_INDEX",
+                pageIndex: state.pageIndex + 1,
+              })
+            }
+          }}
         />
       </div>
 

--- a/src/components/book-editor-ui.tsx
+++ b/src/components/book-editor-ui.tsx
@@ -4,7 +4,7 @@ import { Loader2, ImagePlus, BookText, SquarePlus, Settings2 } from "lucide-reac
 import { useRouter } from "next/navigation"
 import { useReducer } from "react"
 import { AsyncImage } from "@/components/async-image"
-import { getInitialState, PageDraft, reducer } from "@/components/book-editor-state"
+import { getInitialState, isPageEmpty, PageDraft, reducer } from "@/components/book-editor-state"
 import { BookNavButtons } from "@/components/book-nav-buttons"
 import { EditableText } from "@/components/editable-text"
 import { RecordButton } from "@/components/record-button"
@@ -34,6 +34,7 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
   const router = useRouter()
 
   const [state, dispatch] = useReducer(reducer, getInitialState(book, pageIndex))
+  const isLastPage = state.pageIndex === state.pages.length - 1
   const page = state.pages[state.pageIndex]
   const isLoadingTranscript = isLoading(page.caption)
   const { isLoading: isLoadingImage, startedAt } = getLoadingInfo(page.image)
@@ -234,12 +235,10 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
 
         <BookNavButtons
           prevDisabled={state.pageIndex === 0 || isRecording}
-          prevOnClick={() =>
-            dispatch({ type: "SET_PAGE_INDEX", pageIndex: state.pageIndex - 1 })
-          }
-          nextDisabled={isRecording}
+          prevOnClick={() => dispatch({ type: "SET_PAGE_INDEX", pageIndex: state.pageIndex - 1 })}
+          nextDisabled={(isLastPage && isPageEmpty(page)) || isRecording}
           nextOnClick={() => {
-            if (state.pageIndex === state.pages.length - 1) {
+            if (isLastPage) {
               dispatch({ type: "ADD_PAGE" })
             } else {
               dispatch({


### PR DESCRIPTION
## Summary
- allow next page button to automatically add a new page when already on the last page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685b3799946c83249fb15277dd7307bf