### PR TITLE
Improve add page behavior

### DIFF
--- a/src/components/book-editor-state.ts
+++ b/src/components/book-editor-state.ts
@@ -1,5 +1,10 @@
 import { v4 as uuid } from "uuid"
-import { AsyncData, asyncLoaded, asyncNotStarted } from "@/lib/async-data"
+import {
+  AsyncData,
+  asyncLoaded,
+  asyncNotStarted,
+} from "@/lib/async-data"
+import { isPageEmpty } from "@/lib/is-page-empty"
 import { Book, Page } from "@/lib/types"
 
 export interface PageDraft extends Omit<Page, "caption" | "image"> {
@@ -58,12 +63,22 @@ export function reducer(state: State, action: Action): State {
       }
     }
 
-    case "ADD_PAGE":
+    case "ADD_PAGE": {
+      const lastPage = state.pages[state.pages.length - 1]
+
+      if (isPageEmpty(lastPage)) {
+        return {
+          ...state,
+          pageIndex: state.pages.length - 1,
+        }
+      }
+
       return {
         ...state,
         pages: [...state.pages, createEmptyPage()],
         pageIndex: state.pages.length,
       }
+    }
 
     case "UPDATE_PAGE":
       return {

--- a/src/components/book-editor-ui.tsx
+++ b/src/components/book-editor-ui.tsx
@@ -26,6 +26,7 @@ import {
   getValue,
   isLoading,
 } from "@/lib/async-data"
+import { isPageEmpty } from "@/lib/is-page-empty"
 import { upsertBook } from "@/lib/storage"
 import { Book } from "@/lib/types"
 
@@ -60,14 +61,14 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
     upsertBook({
       ...book,
       title: state.title,
-      pages: state.pages
-        .map((page) => ({
-          ...page,
-          caption: getValue(page.caption, "").trim(),
-          image: getValue(page.image, ""),
-        }))
-        .filter((page) => page.caption || page.image),
-    })
+        pages: state.pages
+          .map((page) => ({
+            ...page,
+            caption: getValue(page.caption, "").trim(),
+            image: getValue(page.image, ""),
+          }))
+          .filter((page) => !isPageEmpty(page)),
+      })
 
     router.push(`/books/${book.id}?celebrate=1`)
   }

--- a/src/lib/is-page-empty.ts
+++ b/src/lib/is-page-empty.ts
@@ -1,0 +1,17 @@
+import { AsyncData, getValue } from "@/lib/async-data"
+import { Page } from "@/lib/types"
+export type PageLike = {
+  caption: string | AsyncData<string>
+  image: string | AsyncData<string>
+}
+
+/** Determine if a page draft or saved page has no caption and no image. */
+export function isPageEmpty(page: Page | PageLike): boolean {
+  const caption =
+    typeof page.caption === "string"
+      ? page.caption.trim()
+      : getValue(page.caption, "").trim()
+  const image =
+    typeof page.image === "string" ? page.image : getValue(page.image, "")
+  return caption === "" && image === ""
+}


### PR DESCRIPTION
## Summary
- add `isPageEmpty` utility
- use `isPageEmpty` in book editor reducer
- skip empty pages when saving books

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685b3730b2b88324a00455d28ea548cd