### PR TITLE
Enable wrap-around previous page navigation

### DIFF
--- a/src/components/book-editor-ui.tsx
+++ b/src/components/book-editor-ui.tsx
@@ -234,8 +234,16 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
         </Card>
 
         <BookNavButtons
-          prevDisabled={state.pageIndex === 0 || isRecording}
-          prevOnClick={() => dispatch({ type: "SET_PAGE_INDEX", pageIndex: state.pageIndex - 1 })}
+          prevDisabled={state.pages.length <= 1 || isRecording}
+          prevOnClick={() =>
+            dispatch({
+              type: "SET_PAGE_INDEX",
+              pageIndex:
+                state.pageIndex === 0
+                  ? state.pages.length - 1
+                  : state.pageIndex - 1,
+            })
+          }
           nextDisabled={(isLastPage && isPageEmpty(page)) || isRecording}
           nextOnClick={() => {
             if (isLastPage) {

--- a/src/components/book-editor-ui.tsx
+++ b/src/components/book-editor-ui.tsx
@@ -238,10 +238,7 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
           prevOnClick={() =>
             dispatch({
               type: "SET_PAGE_INDEX",
-              pageIndex:
-                state.pageIndex === 0
-                  ? state.pages.length - 1
-                  : state.pageIndex - 1,
+              pageIndex: state.pageIndex === 0 ? state.pages.length - 1 : state.pageIndex - 1,
             })
           }
           nextDisabled={(isLastPage && isPageEmpty(page)) || isRecording}

--- a/src/components/book-viewer.tsx
+++ b/src/components/book-viewer.tsx
@@ -26,8 +26,7 @@ export function BookViewer({ book, showActions = true }: Props) {
   const swipeHandlers = useSwipeable({
     trackTouch: true,
     trackMouse: false,
-    onSwipedLeft: () =>
-      setPageIndex((prev) => Math.min(prev + 1, pages.length - 1)),
+    onSwipedLeft: () => setPageIndex((prev) => Math.min(prev + 1, pages.length - 1)),
     onSwipedRight: () => setPageIndex((prev) => Math.max(prev - 1, 0)),
   })
 
@@ -89,9 +88,7 @@ export function BookViewer({ book, showActions = true }: Props) {
               <BookNavButtons
                 prevDisabled={pages.length <= 1}
                 prevOnClick={() =>
-                  setPageIndex((prev) =>
-                    prev === 0 ? pages.length - 1 : prev - 1,
-                  )
+                  setPageIndex((prev) => (prev === 0 ? pages.length - 1 : prev - 1))
                 }
                 nextDisabled={pageIndex === pages.length - 1}
                 nextOnClick={() => setPageIndex((prev) => prev + 1)}

--- a/src/components/book-viewer.tsx
+++ b/src/components/book-viewer.tsx
@@ -87,8 +87,12 @@ export function BookViewer({ book, showActions = true }: Props) {
                 />
               )}
               <BookNavButtons
-                prevDisabled={pageIndex === 0}
-                prevOnClick={() => setPageIndex((prev) => prev - 1)}
+                prevDisabled={pages.length <= 1}
+                prevOnClick={() =>
+                  setPageIndex((prev) =>
+                    prev === 0 ? pages.length - 1 : prev - 1,
+                  )
+                }
                 nextDisabled={pageIndex === pages.length - 1}
                 nextOnClick={() => setPageIndex((prev) => prev + 1)}
               />


### PR DESCRIPTION
## Summary
- allow going from the first page to the last page using the previous button in the book viewer
- implement the same wrap-around behavior in the editor

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685c43c62ed48324a390a8bd7ea5834e