### PR TITLE
Refactor image prompt handling

### DIFF
--- a/src/components/book-editor-ui.tsx
+++ b/src/components/book-editor-ui.tsx
@@ -26,6 +26,7 @@ import {
   getValue,
   isLoading,
 } from "@/lib/async-data"
+import { createImagePrompt } from "@/lib/create-image-prompt"
 import { updateBookOnline } from "@/lib/share-book-online"
 import { upsertBook } from "@/lib/storage"
 import { Book } from "@/lib/types"
@@ -92,22 +93,7 @@ export function BookEditor({ book, pageIndex = 0 }: { book: Book; pageIndex?: nu
         .filter((text) => text.length > 0)
         .slice(-3)
 
-      let prompt: string = captionText
-      // Add previous captions to the prompt if available
-      if (previousCaptions.length > 0) {
-        const promptParts: string[] = []
-        promptParts.push("Previous pages:")
-        previousCaptions.forEach((text, idx) => {
-          const num = pageIndex - previousCaptions.length + idx + 1
-          promptParts.push(`${num}. ${text}`)
-        })
-        promptParts.push("Current page:")
-        promptParts.push(captionText)
-        promptParts.push(
-          "Illustrate the current page scene in a consistent style. Do not include any text or captions in the image."
-        )
-        prompt = promptParts.join("\n")
-      }
+      const prompt = createImagePrompt(captionText, previousCaptions, pageIndex)
 
       const res = await fetch("/api/generate-image", {
         method: "POST",

--- a/src/lib/create-image-prompt.ts
+++ b/src/lib/create-image-prompt.ts
@@ -1,0 +1,23 @@
+export function createImagePrompt(
+  caption: string,
+  previousCaptions: string[],
+  pageIndex: number
+): string {
+  const lines: string[] = []
+
+  if (previousCaptions.length > 0) {
+    lines.push("Previous pages:")
+    previousCaptions.forEach((text, idx) => {
+      const num = pageIndex - previousCaptions.length + idx + 1
+      lines.push(`${num}. ${text}`)
+    })
+    lines.push("Current page:")
+  }
+
+  lines.push(caption)
+  lines.push(
+    "Create a colorful illustration for this children's story. Keep the art style consistent across pages. Do not include any text or captions."
+  )
+
+  return lines.join("\n")
+}


### PR DESCRIPTION
## Summary
- add a helper `createImagePrompt` to centralize building the image prompt
- use the helper in the editor UI
- improve the wording of the prompt for consistent, text-free artwork

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6886b3ebf7e083249ea597b6ab6f2e71